### PR TITLE
feat/auth-pages: implementa páginas de autenticação com Server e Clie…

### DIFF
--- a/src/app/(auth)/_data/features.ts
+++ b/src/app/(auth)/_data/features.ts
@@ -1,0 +1,25 @@
+import { DollarSign, TrendingUp, Shield, type LucideIcon } from "lucide-react"
+
+export type AuthFeature = {
+  icon: LucideIcon
+  title: string
+  description: string
+}
+
+export const authFeatures: AuthFeature[] = [
+  {
+    icon: DollarSign,
+    title: "Controle total",
+    description: "Acompanhe receitas e despesas em tempo real",
+  },
+  {
+    icon: TrendingUp,
+    title: "Relatórios inteligentes",
+    description: "Visualize tendências e tome decisões melhores",
+  },
+  {
+    icon: Shield,
+    title: "Segurança avançada",
+    description: "Seus dados protegidos com criptografia de ponta",
+  },
+]

--- a/src/app/(auth)/cadastro/page.tsx
+++ b/src/app/(auth)/cadastro/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { CadastroForm } from "@/components/auth/CadastroForm"
+
+export default function CadastroPage() {
+  return (
+    <Card className="w-full max-w-[440px] shadow-md ring-0">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-2xl font-bold text-foreground tracking-tight">
+          Crie sua conta
+        </CardTitle>
+        <CardDescription className="text-muted-foreground text-sm mt-1">
+          Comece a controlar suas finanças hoje mesmo
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-4">
+        <CadastroForm />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,23 +1,6 @@
 import type { ReactNode } from "react"
-import { DollarSign, TrendingUp, Shield, Clock } from "lucide-react"
-
-const features = [
-  {
-    icon: <DollarSign size={20} />,
-    title: "Controle total",
-    description: "Acompanhe receitas e despesas em tempo real",
-  },
-  {
-    icon: <TrendingUp size={20} />,
-    title: "Relatórios inteligentes",
-    description: "Visualize tendências e tome decisões melhores",
-  },
-  {
-    icon: <Shield size={20} />,
-    title: "Segurança avançada",
-    description: "Seus dados protegidos com criptografia de ponta",
-  },
-]
+import { Clock } from "lucide-react"
+import { authFeatures } from "./_data/features"
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
@@ -68,17 +51,20 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
 
             {/* Features */}
             <ul className="space-y-5">
-              {features.map((f) => (
-                <li key={f.title} className="flex items-start gap-4">
-                  <div className="w-9 h-9 rounded-full bg-[var(--color-brand-secondary)] flex items-center justify-center text-[var(--color-brand-primary)] shrink-0 mt-0.5">
-                    {f.icon}
-                  </div>
-                  <div>
-                    <p className="text-white font-semibold text-sm">{f.title}</p>
-                    <p className="text-white/50 text-sm mt-0.5">{f.description}</p>
-                  </div>
-                </li>
-              ))}
+              {authFeatures.map((f) => {
+                const Icon = f.icon
+                return (
+                  <li key={f.title} className="flex items-start gap-4">
+                    <div className="w-9 h-9 rounded-full bg-[var(--color-brand-secondary)] flex items-center justify-center text-[var(--color-brand-primary)] shrink-0 mt-0.5">
+                      <Icon size={20} />
+                    </div>
+                    <div>
+                      <p className="text-white font-semibold text-sm">{f.title}</p>
+                      <p className="text-white/50 text-sm mt-0.5">{f.description}</p>
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           </div>
 

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,31 +1,19 @@
 import type { ReactNode } from "react"
+import { DollarSign, TrendingUp, Shield, Clock } from "lucide-react"
 
 const features = [
   {
-    icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
-      </svg>
-    ),
+    icon: <DollarSign size={20} />,
     title: "Controle total",
     description: "Acompanhe receitas e despesas em tempo real",
   },
   {
-    icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M3 3v18h18" />
-        <path d="m19 9-5 5-4-4-3 3" />
-      </svg>
-    ),
+    icon: <TrendingUp size={20} />,
     title: "Relatórios inteligentes",
     description: "Visualize tendências e tome decisões melhores",
   },
   {
-    icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-      </svg>
-    ),
+    icon: <Shield size={20} />,
     title: "Segurança avançada",
     description: "Seus dados protegidos com criptografia de ponta",
   },
@@ -38,11 +26,9 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
       <aside className="hidden lg:flex lg:w-[480px] xl:w-[520px] flex-col justify-between relative overflow-hidden bg-[var(--color-brand-tertiary)] shrink-0">
         {/* Padrão decorativo de fundo */}
         <div className="absolute inset-0 pointer-events-none">
-          {/* Círculos decorativos */}
           <div className="absolute -top-24 -left-24 w-96 h-96 rounded-full bg-white/5" />
           <div className="absolute top-1/3 -right-32 w-80 h-80 rounded-full bg-white/5" />
           <div className="absolute -bottom-16 left-16 w-64 h-64 rounded-full bg-white/5" />
-          {/* Grid sutil */}
           <svg className="absolute inset-0 w-full h-full opacity-[0.04]" xmlns="http://www.w3.org/2000/svg">
             <defs>
               <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
@@ -57,12 +43,8 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
         <div className="relative z-10 flex flex-col h-full p-10 xl:p-12">
           {/* Logo */}
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-white/15 flex items-center justify-center backdrop-blur-sm border border-white/20">
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 2a10 10 0 0 1 10 10c0 5.52-4.48 10-10 10S2 17.52 2 12" />
-                <path d="M12 2C6.48 2 2 6.48 2 12" strokeOpacity="0.4" />
-                <path d="M12 6v6l4 2" />
-              </svg>
+            <div className="w-10 h-10 rounded-xl bg-white/15 flex items-center justify-center backdrop-blur-sm border border-white/20 text-white">
+              <Clock size={22} />
             </div>
             <span className="text-white font-bold text-xl tracking-tight">FinanceApp</span>
           </div>
@@ -111,11 +93,8 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
       <main className="flex-1 flex flex-col items-center justify-center p-6 sm:p-10 min-h-screen">
         {/* Logo mobile */}
         <div className="flex lg:hidden items-center gap-2 mb-8">
-          <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M12 2a10 10 0 0 1 10 10c0 5.52-4.48 10-10 10S2 17.52 2 12" />
-              <path d="M12 6v6l4 2" />
-            </svg>
+          <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center text-white">
+            <Clock size={18} />
           </div>
           <span className="text-foreground font-bold text-lg tracking-tight">FinanceApp</span>
         </div>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from "react"
+
+const features = [
+  {
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+      </svg>
+    ),
+    title: "Controle total",
+    description: "Acompanhe receitas e despesas em tempo real",
+  },
+  {
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M3 3v18h18" />
+        <path d="m19 9-5 5-4-4-3 3" />
+      </svg>
+    ),
+    title: "Relatórios inteligentes",
+    description: "Visualize tendências e tome decisões melhores",
+  },
+  {
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+    ),
+    title: "Segurança avançada",
+    description: "Seus dados protegidos com criptografia de ponta",
+  },
+]
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen flex bg-background">
+      {/* Painel esquerdo — oculto em mobile */}
+      <aside className="hidden lg:flex lg:w-[480px] xl:w-[520px] flex-col justify-between relative overflow-hidden bg-[var(--color-brand-tertiary)] shrink-0">
+        {/* Padrão decorativo de fundo */}
+        <div className="absolute inset-0 pointer-events-none">
+          {/* Círculos decorativos */}
+          <div className="absolute -top-24 -left-24 w-96 h-96 rounded-full bg-white/5" />
+          <div className="absolute top-1/3 -right-32 w-80 h-80 rounded-full bg-white/5" />
+          <div className="absolute -bottom-16 left-16 w-64 h-64 rounded-full bg-white/5" />
+          {/* Grid sutil */}
+          <svg className="absolute inset-0 w-full h-full opacity-[0.04]" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                <path d="M 40 0 L 0 0 0 40" fill="none" stroke="white" strokeWidth="1" />
+              </pattern>
+            </defs>
+            <rect width="100%" height="100%" fill="url(#grid)" />
+          </svg>
+        </div>
+
+        {/* Conteúdo do painel */}
+        <div className="relative z-10 flex flex-col h-full p-10 xl:p-12">
+          {/* Logo */}
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl bg-white/15 flex items-center justify-center backdrop-blur-sm border border-white/20">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 2a10 10 0 0 1 10 10c0 5.52-4.48 10-10 10S2 17.52 2 12" />
+                <path d="M12 2C6.48 2 2 6.48 2 12" strokeOpacity="0.4" />
+                <path d="M12 6v6l4 2" />
+              </svg>
+            </div>
+            <span className="text-white font-bold text-xl tracking-tight">FinanceApp</span>
+          </div>
+
+          {/* Título central */}
+          <div className="flex-1 flex flex-col justify-center">
+            <div className="mb-2">
+              <span className="inline-block text-[var(--color-brand-secondary)] text-sm font-medium tracking-widest uppercase mb-4">
+                Gestão Financeira
+              </span>
+            </div>
+            <h1 className="text-white text-4xl xl:text-[2.75rem] font-bold leading-[1.15] mb-5 tracking-tight">
+              Tome o controle<br />das suas finanças
+            </h1>
+            <p className="text-white/60 text-base leading-relaxed max-w-xs">
+              Planeje, acompanhe e evolua. Tudo em um só lugar, de forma simples e segura.
+            </p>
+
+            {/* Divisor */}
+            <div className="w-12 h-px bg-white/20 my-8" />
+
+            {/* Features */}
+            <ul className="space-y-5">
+              {features.map((f) => (
+                <li key={f.title} className="flex items-start gap-4">
+                  <div className="w-9 h-9 rounded-full bg-[var(--color-brand-secondary)] flex items-center justify-center text-[var(--color-brand-primary)] shrink-0 mt-0.5">
+                    {f.icon}
+                  </div>
+                  <div>
+                    <p className="text-white font-semibold text-sm">{f.title}</p>
+                    <p className="text-white/50 text-sm mt-0.5">{f.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Rodapé do painel */}
+          <p className="text-white/30 text-xs">
+            © {new Date().getFullYear()} FinanceApp. Todos os direitos reservados.
+          </p>
+        </div>
+      </aside>
+
+      {/* Área do formulário */}
+      <main className="flex-1 flex flex-col items-center justify-center p-6 sm:p-10 min-h-screen">
+        {/* Logo mobile */}
+        <div className="flex lg:hidden items-center gap-2 mb-8">
+          <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 2a10 10 0 0 1 10 10c0 5.52-4.48 10-10 10S2 17.52 2 12" />
+              <path d="M12 6v6l4 2" />
+            </svg>
+          </div>
+          <span className="text-foreground font-bold text-lg tracking-tight">FinanceApp</span>
+        </div>
+
+        {children}
+      </main>
+    </div>
+  )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { LoginForm } from "@/components/auth/LoginForm"
+
+export default function LoginPage() {
+  return (
+    <Card className="w-full max-w-[420px] shadow-md ring-0">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-2xl font-bold text-foreground tracking-tight">
+          Bem-vindo de volta
+        </CardTitle>
+        <CardDescription className="text-muted-foreground text-sm mt-1">
+          Entre na sua conta para continuar
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-4">
+        <LoginForm />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(auth)/recuperar-senha/page.tsx
+++ b/src/app/(auth)/recuperar-senha/page.tsx
@@ -5,24 +5,26 @@ export default function RecuperarSenhaPage() {
   return (
     <Card className="w-full max-w-[420px] shadow-md ring-0">
       <CardHeader className="pb-2">
-        <div className="w-11 h-11 rounded-xl bg-secondary flex items-center justify-center mb-3">
-          <svg
-            width="22"
-            height="22"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="var(--color-brand-tertiary)"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect width="20" height="16" x="2" y="4" rx="2" />
-            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-          </svg>
+        <div className="flex items-center gap-3 mb-1">
+          <div className="w-10 h-10 rounded-xl bg-secondary flex items-center justify-center shrink-0">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--color-brand-tertiary)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect width="20" height="16" x="2" y="4" rx="2" />
+              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+            </svg>
+          </div>
+          <CardTitle className="text-2xl font-bold text-foreground tracking-tight">
+            Recuperar senha
+          </CardTitle>
         </div>
-        <CardTitle className="text-2xl font-bold text-foreground tracking-tight">
-          Recuperar senha
-        </CardTitle>
         <CardDescription className="text-muted-foreground text-sm mt-1">
           Informe seu e-mail e enviaremos um link para redefinir sua senha
         </CardDescription>

--- a/src/app/(auth)/recuperar-senha/page.tsx
+++ b/src/app/(auth)/recuperar-senha/page.tsx
@@ -1,3 +1,4 @@
+import { Mail } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { RecuperarSenhaForm } from "@/components/auth/RecuperarSenhaForm"
 
@@ -6,20 +7,8 @@ export default function RecuperarSenhaPage() {
     <Card className="w-full max-w-[420px] shadow-md ring-0">
       <CardHeader className="pb-2">
         <div className="flex items-center gap-3 mb-1">
-          <div className="w-10 h-10 rounded-xl bg-secondary flex items-center justify-center shrink-0">
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="var(--color-brand-tertiary)"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <rect width="20" height="16" x="2" y="4" rx="2" />
-              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-            </svg>
+          <div className="w-10 h-10 rounded-xl bg-secondary flex items-center justify-center shrink-0 text-[var(--color-brand-tertiary)]">
+            <Mail size={20} />
           </div>
           <CardTitle className="text-2xl font-bold text-foreground tracking-tight">
             Recuperar senha

--- a/src/app/(auth)/recuperar-senha/page.tsx
+++ b/src/app/(auth)/recuperar-senha/page.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { RecuperarSenhaForm } from "@/components/auth/RecuperarSenhaForm"
+
+export default function RecuperarSenhaPage() {
+  return (
+    <Card className="w-full max-w-[420px] shadow-md ring-0">
+      <CardHeader className="pb-2">
+        <div className="w-11 h-11 rounded-xl bg-secondary flex items-center justify-center mb-3">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-brand-tertiary)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect width="20" height="16" x="2" y="4" rx="2" />
+            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+          </svg>
+        </div>
+        <CardTitle className="text-2xl font-bold text-foreground tracking-tight">
+          Recuperar senha
+        </CardTitle>
+        <CardDescription className="text-muted-foreground text-sm mt-1">
+          Informe seu e-mail e enviaremos um link para redefinir sua senha
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-4">
+        <RecuperarSenhaForm />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/auth/CadastroForm.tsx
+++ b/src/components/auth/CadastroForm.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { PasswordInput } from "@/components/auth/PasswordInput"
+
+function getPasswordStrength(password: string): 0 | 1 | 2 | 3 {
+  if (password.length === 0) return 0
+  let score = 0
+  if (password.length >= 8) score++
+  if (/[A-Z]/.test(password) && /[0-9]/.test(password)) score++
+  if (/[^A-Za-z0-9]/.test(password)) score++
+  return score as 0 | 1 | 2 | 3
+}
+
+const strengthConfig: Record<0 | 1 | 2 | 3, { label: string; bars: boolean[]; color: string }> = {
+  0: { label: "",      bars: [false, false, false], color: "bg-muted" },
+  1: { label: "Fraca", bars: [true,  false, false], color: "bg-destructive" },
+  2: { label: "Média", bars: [true,  true,  false], color: "bg-[var(--color-feedback-warning)]" },
+  3: { label: "Forte", bars: [true,  true,  true],  color: "bg-[var(--color-feedback-success)]" },
+}
+
+export function CadastroForm() {
+  const [password, setPassword] = useState("")
+  const [confirm, setConfirm]   = useState("")
+
+  const strength = getPasswordStrength(password)
+  const { label, bars, color } = strengthConfig[strength]
+  const passwordMismatch = confirm.length > 0 && confirm !== password
+
+  return (
+    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+      {/* Nome */}
+      <div className="space-y-1.5">
+        <Label htmlFor="name" className="text-sm font-medium text-foreground">
+          Nome completo
+        </Label>
+        <Input
+          id="name"
+          type="text"
+          placeholder="João Silva"
+          autoComplete="name"
+          className="h-10 bg-background"
+        />
+      </div>
+
+      {/* E-mail */}
+      <div className="space-y-1.5">
+        <Label htmlFor="email" className="text-sm font-medium text-foreground">
+          E-mail
+        </Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="seu@email.com"
+          autoComplete="email"
+          className="h-10 bg-background"
+        />
+      </div>
+
+      {/* Senha + indicador de força */}
+      <div className="space-y-1.5">
+        <Label htmlFor="password" className="text-sm font-medium text-foreground">
+          Senha
+        </Label>
+        <PasswordInput
+          id="password"
+          placeholder="Mínimo 8 caracteres"
+          autoComplete="new-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {password.length > 0 && (
+          <div className="space-y-1.5 pt-1">
+            <div className="flex gap-1.5">
+              {bars.map((active, i) => (
+                <div
+                  key={i}
+                  className={`h-1 flex-1 rounded-full transition-all duration-300 ${active ? color : "bg-muted"}`}
+                />
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Força da senha:{" "}
+              <span className={
+                strength === 3 ? "text-[var(--color-feedback-success)] font-medium"
+                : strength === 2 ? "text-[var(--color-feedback-warning)] font-medium"
+                : "text-destructive font-medium"
+              }>
+                {label}
+              </span>
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Confirmar senha */}
+      <div className="space-y-1.5">
+        <Label htmlFor="confirm" className="text-sm font-medium text-foreground">
+          Confirmar senha
+        </Label>
+        <PasswordInput
+          id="confirm"
+          placeholder="Repita a senha"
+          autoComplete="new-password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          aria-invalid={passwordMismatch}
+          className={passwordMismatch ? "border-destructive focus-visible:ring-destructive/20" : ""}
+        />
+        {passwordMismatch && (
+          <p className="text-xs text-destructive">As senhas não coincidem</p>
+        )}
+      </div>
+
+      <Button type="submit" className="w-full h-10 mt-2 font-semibold" disabled={passwordMismatch}>
+        Criar conta
+      </Button>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Já tem uma conta?{" "}
+        <Link href="/login" className="text-primary font-semibold hover:underline">
+          Entrar
+        </Link>
+      </p>
+    </form>
+  )
+}

--- a/src/components/auth/CadastroForm.tsx
+++ b/src/components/auth/CadastroForm.tsx
@@ -6,29 +6,12 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { PasswordInput } from "@/components/auth/PasswordInput"
-
-function getPasswordStrength(password: string): 0 | 1 | 2 | 3 {
-  if (password.length === 0) return 0
-  let score = 0
-  if (password.length >= 8) score++
-  if (/[A-Z]/.test(password) && /[0-9]/.test(password)) score++
-  if (/[^A-Za-z0-9]/.test(password)) score++
-  return score as 0 | 1 | 2 | 3
-}
-
-const strengthConfig: Record<0 | 1 | 2 | 3, { label: string; bars: boolean[]; color: string }> = {
-  0: { label: "",      bars: [false, false, false], color: "bg-muted" },
-  1: { label: "Fraca", bars: [true,  false, false], color: "bg-destructive" },
-  2: { label: "Média", bars: [true,  true,  false], color: "bg-[var(--color-feedback-warning)]" },
-  3: { label: "Forte", bars: [true,  true,  true],  color: "bg-[var(--color-feedback-success)]" },
-}
+import { PasswordStrengthIndicator } from "@/components/auth/PasswordStrengthIndicator"
 
 export function CadastroForm() {
   const [password, setPassword] = useState("")
-  const [confirm, setConfirm]   = useState("")
+  const [confirm, setConfirm] = useState("")
 
-  const strength = getPasswordStrength(password)
-  const { label, bars, color } = strengthConfig[strength]
   const passwordMismatch = confirm.length > 0 && confirm !== password
 
   return (
@@ -73,28 +56,7 @@ export function CadastroForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        {password.length > 0 && (
-          <div className="space-y-1.5 pt-1">
-            <div className="flex gap-1.5">
-              {bars.map((active, i) => (
-                <div
-                  key={i}
-                  className={`h-1 flex-1 rounded-full transition-all duration-300 ${active ? color : "bg-muted"}`}
-                />
-              ))}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Força da senha:{" "}
-              <span className={
-                strength === 3 ? "text-[var(--color-feedback-success)] font-medium"
-                : strength === 2 ? "text-[var(--color-feedback-warning)] font-medium"
-                : "text-destructive font-medium"
-              }>
-                {label}
-              </span>
-            </p>
-          </div>
-        )}
+        <PasswordStrengthIndicator password={password} />
       </div>
 
       {/* Confirmar senha */}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useState } from "react"
+import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -7,8 +9,37 @@ import { Label } from "@/components/ui/label"
 import { PasswordInput } from "@/components/auth/PasswordInput"
 
 export function LoginForm() {
+  const router = useRouter()
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api"}/user`
+      )
+      const user = await res.json()
+
+      if (user.email === email && user.password === password) {
+        router.push("/dashboard")
+      } else {
+        setError("E-mail ou senha incorretos.")
+      }
+    } catch {
+      setError("Não foi possível conectar ao servidor.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
-    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+    <form className="space-y-4" onSubmit={handleSubmit}>
       {/* E-mail */}
       <div className="space-y-1.5">
         <Label htmlFor="email" className="text-sm font-medium text-foreground">
@@ -20,6 +51,9 @@ export function LoginForm() {
           placeholder="seu@email.com"
           autoComplete="email"
           className="h-10 bg-background"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
         />
       </div>
 
@@ -36,12 +70,22 @@ export function LoginForm() {
             Esqueci minha senha
           </Link>
         </div>
-        <PasswordInput id="password" autoComplete="current-password" />
+        <PasswordInput
+          id="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
       </div>
 
+      {/* Erro */}
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
       {/* Botão */}
-      <Button type="submit" className="w-full h-10 mt-2 font-semibold">
-        Entrar
+      <Button type="submit" className="w-full h-10 mt-2 font-semibold" disabled={loading}>
+        {loading ? "Entrando..." : "Entrar"}
       </Button>
 
       {/* Divisor */}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { PasswordInput } from "@/components/auth/PasswordInput"
+
+export function LoginForm() {
+  return (
+    <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+      {/* E-mail */}
+      <div className="space-y-1.5">
+        <Label htmlFor="email" className="text-sm font-medium text-foreground">
+          E-mail
+        </Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="seu@email.com"
+          autoComplete="email"
+          className="h-10 bg-background"
+        />
+      </div>
+
+      {/* Senha */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="password" className="text-sm font-medium text-foreground">
+            Senha
+          </Label>
+          <Link
+            href="/recuperar-senha"
+            className="text-xs text-primary hover:underline font-medium"
+          >
+            Esqueci minha senha
+          </Link>
+        </div>
+        <PasswordInput id="password" autoComplete="current-password" />
+      </div>
+
+      {/* Botão */}
+      <Button type="submit" className="w-full h-10 mt-2 font-semibold">
+        Entrar
+      </Button>
+
+      {/* Divisor */}
+      <div className="relative my-1">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t border-border" />
+        </div>
+        <div className="relative flex justify-center text-xs">
+          <span className="bg-card px-3 text-muted-foreground">ou</span>
+        </div>
+      </div>
+
+      {/* Link de cadastro */}
+      <p className="text-center text-sm text-muted-foreground">
+        Não tem uma conta?{" "}
+        <Link href="/cadastro" className="text-primary font-semibold hover:underline">
+          Cadastre-se grátis
+        </Link>
+      </p>
+    </form>
+  )
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -49,6 +49,8 @@ export function LoginForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
+          onInvalid={(e) => (e.target as HTMLInputElement).setCustomValidity("Preencha este campo")}
+          onInput={(e) => (e.target as HTMLInputElement).setCustomValidity("")}
         />
       </div>
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -24,13 +24,8 @@ export function LoginForm() {
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api"}/user`
       )
-      const user = await res.json()
-
-      if (user.email === email && user.password === password) {
-        router.push("/dashboard")
-      } else {
-        setError("E-mail ou senha incorretos.")
-      }
+      if (!res.ok) throw new Error()
+      router.push("/dashboard")
     } catch {
       setError("Não foi possível conectar ao servidor.")
     } finally {

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+
+interface PasswordInputProps {
+  id: string
+  placeholder?: string
+  autoComplete?: string
+  value?: string
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  className?: string
+  "aria-invalid"?: boolean
+}
+
+export function PasswordInput({
+  id,
+  placeholder = "••••••••",
+  autoComplete,
+  value,
+  onChange,
+  className,
+  "aria-invalid": ariaInvalid,
+}: PasswordInputProps) {
+  const [show, setShow] = useState(false)
+
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        type={show ? "text" : "password"}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        value={value}
+        onChange={onChange}
+        className={`h-10 bg-background pr-10 ${className ?? ""}`}
+        aria-invalid={ariaInvalid}
+      />
+      <button
+        type="button"
+        onClick={() => setShow((v) => !v)}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+        aria-label={show ? "Ocultar senha" : "Mostrar senha"}
+      >
+        {show ? (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+            <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+            <line x1="1" y1="1" x2="23" y2="23" />
+          </svg>
+        ) : (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+        )}
+      </button>
+    </div>
+  )
+}

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { Eye, EyeOff } from "lucide-react"
 import { Input } from "@/components/ui/input"
 
 interface PasswordInputProps {
@@ -42,18 +43,7 @@ export function PasswordInput({
         className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
         aria-label={show ? "Ocultar senha" : "Mostrar senha"}
       >
-        {show ? (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-            <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-            <line x1="1" y1="1" x2="23" y2="23" />
-          </svg>
-        ) : (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-            <circle cx="12" cy="12" r="3" />
-          </svg>
-        )}
+        {show ? <EyeOff size={16} /> : <Eye size={16} />}
       </button>
     </div>
   )

--- a/src/components/auth/PasswordStrengthIndicator.tsx
+++ b/src/components/auth/PasswordStrengthIndicator.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+function getPasswordStrength(password: string): 0 | 1 | 2 | 3 {
+  if (password.length === 0) return 0
+  let score = 0
+  if (password.length >= 8) score++
+  if (/[A-Z]/.test(password) && /[0-9]/.test(password)) score++
+  if (/[^A-Za-z0-9]/.test(password)) score++
+  return score as 0 | 1 | 2 | 3
+}
+
+const strengthConfig: Record<0 | 1 | 2 | 3, { label: string; bars: boolean[]; color: string }> = {
+  0: { label: "",      bars: [false, false, false], color: "bg-muted" },
+  1: { label: "Fraca", bars: [true,  false, false], color: "bg-destructive" },
+  2: { label: "Média", bars: [true,  true,  false], color: "bg-[var(--color-feedback-warning)]" },
+  3: { label: "Forte", bars: [true,  true,  true],  color: "bg-[var(--color-feedback-success)]" },
+}
+
+interface PasswordStrengthIndicatorProps {
+  password: string
+}
+
+export function PasswordStrengthIndicator({ password }: PasswordStrengthIndicatorProps) {
+  if (password.length === 0) return null
+
+  const strength = getPasswordStrength(password)
+  const { label, bars, color } = strengthConfig[strength]
+
+  return (
+    <div className="space-y-1.5 pt-1">
+      <div className="flex gap-1.5">
+        {bars.map((active, i) => (
+          <div
+            key={i}
+            className={`h-1 flex-1 rounded-full transition-all duration-300 ${active ? color : "bg-muted"}`}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Força da senha:{" "}
+        <span className={
+          strength === 3 ? "text-[var(--color-feedback-success)] font-medium"
+          : strength === 2 ? "text-[var(--color-feedback-warning)] font-medium"
+          : "text-destructive font-medium"
+        }>
+          {label}
+        </span>
+      </p>
+    </div>
+  )
+}

--- a/src/components/auth/RecuperarSenhaForm.tsx
+++ b/src/components/auth/RecuperarSenhaForm.tsx
@@ -2,50 +2,18 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { CheckCircle, ArrowLeft } from "lucide-react"
+import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { RecuperarSenhaSuccess } from "@/components/auth/RecuperarSenhaSuccess"
 
 export function RecuperarSenhaForm() {
   const [sent, setSent] = useState(false)
   const [email, setEmail] = useState("")
 
   if (sent) {
-    return (
-      <div className="flex flex-col items-center text-center gap-4 py-4">
-        <div className="w-16 h-16 rounded-full bg-[var(--color-feedback-success)]/10 flex items-center justify-center">
-          <CheckCircle size={32} stroke="var(--color-feedback-success)" />
-        </div>
-
-        <div className="space-y-2">
-          <h2 className="text-xl font-bold text-foreground tracking-tight">E-mail enviado!</h2>
-          <p className="text-sm text-muted-foreground max-w-xs">
-            Enviamos um link de recuperação para{" "}
-            <span className="font-medium text-foreground">{email}</span>.
-            Verifique sua caixa de entrada.
-          </p>
-        </div>
-
-        <div className="w-full pt-2 space-y-3">
-          <Button variant="outline" className="w-full h-10" onClick={() => setSent(false)}>
-            Usar outro e-mail
-          </Button>
-          <Link href="/login" className="block">
-            <Button variant="ghost" className="w-full h-10 text-primary">
-              Voltar para o login
-            </Button>
-          </Link>
-        </div>
-
-        <p className="text-xs text-muted-foreground pt-2">
-          Não recebeu?{" "}
-          <button onClick={() => setSent(false)} className="text-primary hover:underline font-medium">
-            Reenviar e-mail
-          </button>
-        </p>
-      </div>
-    )
+    return <RecuperarSenhaSuccess email={email} onReset={() => setSent(false)} />
   }
 
   return (

--- a/src/components/auth/RecuperarSenhaForm.tsx
+++ b/src/components/auth/RecuperarSenhaForm.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export function RecuperarSenhaForm() {
+  const [sent, setSent] = useState(false)
+  const [email, setEmail] = useState("")
+
+  if (sent) {
+    return (
+      <div className="flex flex-col items-center text-center gap-4 py-4">
+        <div className="w-16 h-16 rounded-full bg-[var(--color-feedback-success)]/10 flex items-center justify-center">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--color-feedback-success)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+            <polyline points="22 4 12 14.01 9 11.01" />
+          </svg>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-bold text-foreground tracking-tight">E-mail enviado!</h2>
+          <p className="text-sm text-muted-foreground max-w-xs">
+            Enviamos um link de recuperação para{" "}
+            <span className="font-medium text-foreground">{email}</span>.
+            Verifique sua caixa de entrada.
+          </p>
+        </div>
+
+        <div className="w-full pt-2 space-y-3">
+          <Button variant="outline" className="w-full h-10" onClick={() => setSent(false)}>
+            Usar outro e-mail
+          </Button>
+          <Link href="/login" className="block">
+            <Button variant="ghost" className="w-full h-10 text-primary">
+              Voltar para o login
+            </Button>
+          </Link>
+        </div>
+
+        <p className="text-xs text-muted-foreground pt-2">
+          Não recebeu?{" "}
+          <button onClick={() => setSent(false)} className="text-primary hover:underline font-medium">
+            Reenviar e-mail
+          </button>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (email) setSent(true)
+      }}
+    >
+      <div className="space-y-1.5">
+        <Label htmlFor="email" className="text-sm font-medium text-foreground">
+          E-mail cadastrado
+        </Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="seu@email.com"
+          autoComplete="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="h-10 bg-background"
+          required
+        />
+      </div>
+
+      <Button type="submit" className="w-full h-10 font-semibold mt-2">
+        Enviar link de recuperação
+      </Button>
+
+      <Link href="/login" className="block">
+        <Button type="button" variant="ghost" className="w-full h-10 text-muted-foreground hover:text-foreground">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+          Voltar para o login
+        </Button>
+      </Link>
+    </form>
+  )
+}

--- a/src/components/auth/RecuperarSenhaForm.tsx
+++ b/src/components/auth/RecuperarSenhaForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import Link from "next/link"
+import { CheckCircle, ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -14,10 +15,7 @@ export function RecuperarSenhaForm() {
     return (
       <div className="flex flex-col items-center text-center gap-4 py-4">
         <div className="w-16 h-16 rounded-full bg-[var(--color-feedback-success)]/10 flex items-center justify-center">
-          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--color-feedback-success)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-            <polyline points="22 4 12 14.01 9 11.01" />
-          </svg>
+          <CheckCircle size={32} stroke="var(--color-feedback-success)" />
         </div>
 
         <div className="space-y-2">
@@ -80,9 +78,7 @@ export function RecuperarSenhaForm() {
 
       <Link href="/login" className="block">
         <Button type="button" variant="ghost" className="w-full h-10 text-muted-foreground hover:text-foreground">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2">
-            <path d="m15 18-6-6 6-6" />
-          </svg>
+          <ArrowLeft size={16} className="mr-2" />
           Voltar para o login
         </Button>
       </Link>

--- a/src/components/auth/RecuperarSenhaSuccess.tsx
+++ b/src/components/auth/RecuperarSenhaSuccess.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import Link from "next/link"
+import { CheckCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface RecuperarSenhaSuccessProps {
+  email: string
+  onReset: () => void
+}
+
+export function RecuperarSenhaSuccess({ email, onReset }: RecuperarSenhaSuccessProps) {
+  return (
+    <div className="flex flex-col items-center text-center gap-4 py-4">
+      <div className="w-16 h-16 rounded-full bg-[var(--color-feedback-success)]/10 flex items-center justify-center">
+        <CheckCircle size={32} stroke="var(--color-feedback-success)" />
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-bold text-foreground tracking-tight">E-mail enviado!</h2>
+        <p className="text-sm text-muted-foreground max-w-xs">
+          Enviamos um link de recuperação para{" "}
+          <span className="font-medium text-foreground">{email}</span>.
+          Verifique sua caixa de entrada.
+        </p>
+      </div>
+
+      <div className="w-full pt-2 space-y-3">
+        <Button variant="outline" className="w-full h-10" onClick={onReset}>
+          Usar outro e-mail
+        </Button>
+        <Link href="/login" className="block">
+          <Button variant="ghost" className="w-full h-10 text-primary">
+            Voltar para o login
+          </Button>
+        </Link>
+      </div>
+
+      <p className="text-xs text-muted-foreground pt-2">
+        Não recebeu?{" "}
+        <button onClick={onReset} className="text-primary hover:underline font-medium">
+          Reenviar e-mail
+        </button>
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION

<img width="1262" height="940" alt="image" src="https://github.com/user-attachments/assets/127cf9a3-6ae1-48e0-a2a8-59ee89a033e5" />


Components

- Cria layout de auth com painel esquerdo decorativo (cor terciária) e área de formulário
- Adiciona LoginPage com card sem borda, LoginForm com toggle de senha e link para cadastro
- Adiciona CadastroPage com CadastroForm incluindo indicador de força de senha (3 barras)
- Adiciona RecuperarSenhaPage com RecuperarSenhaForm e estado de sucesso após envio
- Extrai PasswordInput como componente client reutilizável com show/hide
- Ícones das features com fundo circular na cor secundária e ícone na cor primária
- Preserva arquitetura Server Component nas pages, isolando interatividade em islands client